### PR TITLE
Fix argument placement for Huggingface pipeline

### DIFF
--- a/dags/news_sentiment_dag.py
+++ b/dags/news_sentiment_dag.py
@@ -73,11 +73,11 @@ def run_sentiment_pipeline(**kwargs):
         model=model,
         tokenizer=tokenizer,
         device=device,
-        max_length=MAX_LENGTH,
-        truncation=True,
     )
 
-    sentiment_results = sentiment_pipeline(texts)
+    sentiment_results = sentiment_pipeline(
+        texts, truncation=True, max_length=MAX_LENGTH
+    )
 
     # track the results with mlflow
     mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)

--- a/model_selection/utils.py
+++ b/model_selection/utils.py
@@ -74,8 +74,6 @@ def run_model(MODEL_NAME, MAX_LENGTH, LABEL_MAP, TEST_DF, DF_NAME):
         model=model,
         tokenizer=tokenizer,
         device=device,
-        max_length=MAX_LENGTH,
-        truncation=True,
     )
 
     texts = TEST_DF.iloc[:, 0].values
@@ -87,7 +85,9 @@ def run_model(MODEL_NAME, MAX_LENGTH, LABEL_MAP, TEST_DF, DF_NAME):
     start_time = time.time()
     for i in tqdm(range(0, len(texts), batch_size)):
         batch = texts[i : i + batch_size]
-        output = sentiment_pipeline(batch.tolist(), truncation=True)
+        output = sentiment_pipeline(
+            batch.tolist(), truncation=True, max_length=MAX_LENGTH
+        )
         logs.extend(output)
     end_time = time.time()
 
@@ -108,7 +108,7 @@ def run_model(MODEL_NAME, MAX_LENGTH, LABEL_MAP, TEST_DF, DF_NAME):
 
     print("Model Name: ", MODEL_NAME)
     print("Token Max Length: ", MAX_LENGTH)
-    print("Dataset: ", "IMDB")
+    print("Dataset: ", DF_NAME)
     print("Pos-Neg Ratio: ", TEST_DF.iloc[:, 1].value_counts(normalize=True)[1])
     print("Accuracy: ", acc)
     print("F1 Score: ", f1)


### PR DESCRIPTION
## Summary
- fix dataset name print
- send truncation parameters when invoking the pipeline
- adjust Airflow DAG sentiment call

## Testing
- `python -m py_compile dags/news_sentiment_dag.py model_selection/amazon_runs.py model_selection/imdb_runs.py model_selection/reviews_runs.py model_selection/utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ffa5c5b8c8332841c2b05e485a1f1